### PR TITLE
Add Props and State type arguments to class components

### DIFF
--- a/src/common/components/addons/RoutingWrapper/index.jsx
+++ b/src/common/components/addons/RoutingWrapper/index.jsx
@@ -16,7 +16,7 @@ type Props = {
  * @desc This function returns JSX, so we can think about it as "stateless component"
  * @param {Function} authCheck checks is user logged in
  */
-export default class RoutingWrapper extends Component {
+export default class RoutingWrapper extends Component <Props> {
 	props: Props
 	/**
     * Checks Auth logic. Is user allowed to visit certain path?

--- a/src/common/components/parts/Root/index.jsx
+++ b/src/common/components/parts/Root/index.jsx
@@ -25,7 +25,7 @@ type Props = {
 	routes: Array<RouteItem>
 }
 
-export default class Root extends Component {
+export default class Root extends Component <Props> {
 	props: Props
 
 	static defaultProps = {

--- a/src/common/components/parts/Sidebar/index.jsx
+++ b/src/common/components/parts/Sidebar/index.jsx
@@ -19,7 +19,7 @@ type Props = {
 	isMobile: boolean
 }
 
-class SidebarComponent extends Component {
+class SidebarComponent extends Component <Props> {
 	props: Props
 
 	render () {

--- a/src/common/containers/App/index.jsx
+++ b/src/common/containers/App/index.jsx
@@ -51,7 +51,7 @@ type Props = {
 	isMobileSM: boolean
 }
 
-class App extends Component {
+class App extends Component <Props> {
 	props: Props
 	componentWillMount () {
 		const {isLoggedIn} = this.props

--- a/src/common/containers/Links/index.jsx
+++ b/src/common/containers/Links/index.jsx
@@ -17,7 +17,7 @@ type Props = {
 	isLinksLoaded: boolean
 }
 
-class Links extends Component {
+class Links extends Component <Props> {
 	props: Props
 
 	componentDidMount () {

--- a/src/common/containers/Login/components/index.jsx
+++ b/src/common/containers/Login/components/index.jsx
@@ -14,7 +14,7 @@ type State = {
 	password: string
 }
 
-class LoginComponent extends Component {
+class LoginComponent extends Component <Props, State> {
 	props: Props
 	state: State = {
 		username: '',


### PR DESCRIPTION
Flow throws the error:

> flow says identifier `Component`: Too few type arguments. Expected at least 1

if class components don't have "\<Props\>" and/or "\<State\>" type arguments after the Component keyword and before the opening curly brace. Type arguments are added to the respective class components to resolve this issue.