### PR TITLE
Add missing type annotations to handleChange method in LoginComponent

### DIFF
--- a/src/common/containers/Login/components/index.jsx
+++ b/src/common/containers/Login/components/index.jsx
@@ -27,7 +27,7 @@ class LoginComponent extends Component {
 		this.props.login({username, password})
 	}
 
-	handleChange = (e: Event, {name, value}) => {
+	handleChange = (e: Event, {name, value}: {name: string, value: string}) => {
 		this.setState({
 			[name]: value
 		})


### PR DESCRIPTION
Missing type annotations for destructed "name" and "value" arguments
in the handleChange method arguments of LoginComponent.