### PR TITLE
Add disable flow comment and suppress template string coercion errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,3 +13,4 @@ all=warn
 module.system.node.resolve_dirname=node_modules
 module.system.node.resolve_dirname=src/common
 module.system.node.resolve_dirname=src
+suppress_comment= \\(.\\|\n\\)*\\flow-disable-next-line

--- a/src/common/routing/routes.js
+++ b/src/common/routing/routes.js
@@ -9,6 +9,7 @@ import type {RouteItem} from 'types'
 
 function asyncComponentCreator (url) {
 	return asyncComponent({
+		// flow-disable-next-line: The parameter passed to import() must be a literal string
 		resolve: () => import(/* webpackChunkName:"[index].[request]" */ `containers/${url}/index.jsx`),
 		LoadingComponent () {
 			return (

--- a/src/server/ssr/stats.js
+++ b/src/server/ssr/stats.js
@@ -37,7 +37,9 @@ async function getFile (path) {
 
 export default async function () {
 	const basePath = process.env.CLIENT_DIST_PATH
+	// flow-disable-next-line: This type cannot be coerced to string
 	const assets = await getFile(`${basePath}/webpack-assets.json`)
+	// flow-disable-next-line: This type cannot be coerced to string
 	const faviconsAssets = await getFile(`${basePath}/favicons-stats.json`)
 
 	return {


### PR DESCRIPTION
Add the suppress comment statement to .flowconfig. When used in code,
the comment allows the suppression of flow errors on the following line.
This utility is used to suppress template string coercion errors which are
not yet well support by flow.