### PR TITLE
fix(server):  make ssr properly return 404

### DIFF
--- a/src/server/ssr/index.js
+++ b/src/server/ssr/index.js
@@ -3,7 +3,6 @@
  * @desc
  */
 import React from 'react'
-import _ from 'lodash'
 import {renderToNodeStream} from 'react-dom/server'
 import {ServerStyleSheet, StyleSheetManager} from 'styled-components'
 import {configureRootComponent, configureApp} from 'common/app'
@@ -42,8 +41,9 @@ export default async (req: express$Request, res: express$Response) => {
 		</AsyncComponentProvider>
 	)
 
+	// match url against browseable routes
 	// if true - > throw 404, if match found -> 200
-	const noRequestURLMatch = !_.find(routes, a => matchPath(req.url, a.path))
+	const noRequestURLMatch = !routes.filter(r => !!r.path).find(r => matchPath(req.url, r))
 
 	asyncBootstrapper(app).then(() => {
 		const appStream = renderToNodeStream(app)


### PR DESCRIPTION
This PR contains fix making ssr properly response with 404

#### **What is the expected behavior?**
Go to `/non-existing-route `, server should response with 404 Not Found

#### **What is the current behavior?**
Server responses with 200

#### **In case you might need it**

Refer to react-router code, matchPath() has default value for `path` if it's not given. This make non existing path always got `/`. 

https://github.com/ReactTraining/react-router/blob/137a37b0a925a1be50c7f25aa3913dfa3441a391/packages/react-router/modules/matchPath.js#L47