### PR TITLE
fix: root is now rendered only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "offline-plugin": "^4.9.0",
     "raven": "^2.4.1",
     "react": "^16.2.0",
-    "react-async-bootstrapper": "^1.1.2",
+    "react-async-bootstrapper": "^2.1.0",
     "react-async-component": "^1.0.2",
     "react-dom": "^16.2.0",
     "react-ga": "^2.4.1",

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -55,7 +55,7 @@ const app = (
 	</AppContainer>
 )
 
-asyncBootstrapper(app).then(() => {
+asyncBootstrapper(app, false, { asyncBootstrapPhase: true }).then(() => {
 	console.log('__INITIAL_STATE__:', initialState)
 	hydrate(app, document.getElementById('app'))
 })

--- a/src/common/components/Root/index.jsx
+++ b/src/common/components/Root/index.jsx
@@ -23,13 +23,6 @@ const Router = process.env.BROWSER
 	? require('react-router-redux').ConnectedRouter
 	: require('react-router').StaticRouter
 
-let initAlready = false
-// react-async-bootstrapper renders <Root /> twice, because it's based on react-tree-walker
-// react-tree-walker walks in React node tree and resolves promises.
-// This behaviour allow apps to make server-side data fetching.
-// But this approach has 2 drawbacks:
-// Root rendered twice + APPLICATION_INIT dispatched twice
-// `initAlready` ensures that `APPLICATION_INIT` was dispatched only once.
 class Root extends Component<Props> {
 	static defaultProps = {
 		SSR: {}
@@ -37,15 +30,15 @@ class Root extends Component<Props> {
 
 	componentWillMount () {
 		const {store, i18n} = this.props
-		if (!initAlready) {
+		const {asyncBootstrapPhase} = this.context
+		if (!asyncBootstrapPhase) {
 			store.dispatch({type: APPLICATION_INIT})
 			addLocaleData(i18n.localeData)
 		}
-		initAlready = true
 	}
 
 	render () {
-		if (!initAlready) {
+		if (this.context.asyncBootstrapPhase) {
 			return null
 		}
 		const {SSR, store, history, i18n} = this.props


### PR DESCRIPTION
Before, there was only fix for dispatching `APPLICATION_INIT` once. However Root component was rendered twice. `initAlready` wasn't working as expected.

Proof.
![](https://lh3.googleusercontent.com/QGpjTtWw6BFG0-ycm5vnocmvG4_Tbezmt-mIdZTpbIIly09s089IuCQKhoiYI87p0MU86GeMCeGNG5I7IzuT=w1920-h935)

This PR fixes this behaviour by updating the react-async-bootstrapper. [react-async-bootstrapper](https://github.com/ctrlplusb/react-async-bootstrapper) has been updated to [v2.1.0](https://github.com/ctrlplusb/react-async-bootstrapper/releases/tag/v2.1.0) which added an ability to expose bootstrapper context to components. 

Now `<Root />` renders only once. 
![](https://lh4.googleusercontent.com/5kXMc5RSx_5A3pUFSvjoXfdX1PivEhRoOGd85Fnf7d8gLzV8mBj52oQoc4XTdDjdKWvuArZphap2xv_UULGc=w1920-h935)

Based on this [issue](https://github.com/ctrlplusb/react-async-bootstrapper/issues/3#issuecomment-374898091)