### PR TITLE
fix: webpack server config will omit image output

### DIFF
--- a/webpack_config/client/webpack.base.js
+++ b/webpack_config/client/webpack.base.js
@@ -59,6 +59,18 @@ const baseBuild = {
 			{
 				test: /\.(ico|eot|otf|webp|ttf|woff|woff2)$/i,
 				use: `file-loader?limit=100000&name=assets/[name].[hash:6].[ext]`
+			},
+			{
+				test: /\.(jpe?g|png|gif|svg)$/,
+				use: [
+					{
+						loader: 'url-loader',
+						options: {
+							limit: 4096,
+							name: 'images/[name].[hash:6].[ext]'
+						}
+					}
+				]
 			}
 		])
 	},

--- a/webpack_config/server/webpack.base.js
+++ b/webpack_config/server/webpack.base.js
@@ -50,7 +50,21 @@ const baseWebpackConfig = {
 		alias: isomorphicWebpackConfig.resolve.alias
 	},
 	module: {
-		rules: isomorphicWebpackConfig.module.rules
+		rules: isomorphicWebpackConfig.module.rules.concat(
+			{
+				test: /\.(jpe?g|png|gif|svg)$/,
+				use: [
+					{
+						loader: 'url-loader',
+						options: {
+							limit: 4096,
+							name: 'images/[name].[hash:6].[ext]',
+							emitFile: false
+						}
+					}
+				]
+			}
+		)
 	},
 	plugins: isomorphicWebpackConfig.plugins.concat([
 		new webpack.DefinePlugin(definePluginArgs),

--- a/webpack_config/webpack.isomorphic.js
+++ b/webpack_config/webpack.isomorphic.js
@@ -48,18 +48,6 @@ export default {
 				test: /\.(js|jsx)$/,
 				use: 'babel-loader',
 				exclude: [/node_modules/]
-			},
-			{
-				test: /\.(jpe?g|png|gif|svg)$/,
-				use: [
-					{
-						loader: 'url-loader',
-						options: {
-							limit: 4096,
-							name: 'images/[name].[hash:6].[ext]'
-						}
-					}
-				]
 			}
 		]
 	},


### PR DESCRIPTION
This splits the `url-loader` rule into the client and server configs with the only difference being whether the file is emitted by webpack or not. In the server rendered page, `src` tags will still have the correct file path.